### PR TITLE
将 Jacobian 加入 MCP 资源目录

### DIFF
--- a/catalog/mcp/curated.json
+++ b/catalog/mcp/curated.json
@@ -750,5 +750,38 @@
     "source": "curated",
     "added_at": "2026-08-23",
     "last_synced": "2026-08-23"
+  },
+  {
+    "id": "jacobian",
+    "name": "Jacobian",
+    "type": "mcp",
+    "description": "面向可组合数学的 MCP 服务器、CLI 和 Python 库，支持多项式映射、线性代数与图算法的精确计算和猜想检验。",
+    "source_url": "https://github.com/morluto/jacobian",
+    "stars": 13,
+    "category": "tooling",
+    "tags": [
+      "math",
+      "linear-algebra",
+      "polynomial",
+      "graph-algorithms",
+      "mcp-server"
+    ],
+    "tech_stack": [
+      "python"
+    ],
+    "install": {
+      "method": "mcp_config",
+      "config": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "jacobian",
+          "mcp"
+        ]
+      }
+    },
+    "source": "curated",
+    "last_synced": "2026-08-04",
+    "added_at": "2026-08-04"
   }
 ]


### PR DESCRIPTION
将 Jacobian 加入 MCP 服务器精选目录。仅修改 catalog/mcp/curated.json，新增一个条目，未修改其他文件。

项目简介：Jacobian 是一个面向可组合数学的 MCP 服务器、CLI 和 Python 库，支持多项式映射、线性代数与图算法的精确计算和猜想检验。

收录理由：它提供可安装、可直接调用的数学计算能力，并公开 MCP 入口、命令行工具和 Python 库。条目使用本目录要求的结构，包含来源、分类、标签、技术栈和安装配置。

安装配置：npx -y jacobian mcp

验证：

- jq empty catalog/mcp/curated.json