### PR TITLE
catalog: add deja MCP server

### DIFF
--- a/catalog/mcp/curated.json
+++ b/catalog/mcp/curated.json
@@ -719,5 +719,36 @@
     "source": "curated",
     "last_synced": "2026-04-09",
     "added_at": "2026-04-09"
+  },
+  {
+    "id": "deja-vu",
+    "name": "deja",
+    "type": "mcp",
+    "description": "Recall past coding sessions across every agent on the machine, from the transcripts they already wrote",
+    "source_url": "https://github.com/vshulcz/deja-vu",
+    "stars": 665,
+    "category": "tooling",
+    "tags": [
+      "memory",
+      "recall",
+      "session-history",
+      "search",
+      "local-first"
+    ],
+    "tech_stack": [
+      "go"
+    ],
+    "install": {
+      "method": "mcp_config",
+      "config": {
+        "command": "deja",
+        "args": [
+          "mcp"
+        ]
+      }
+    },
+    "source": "curated",
+    "added_at": "2026-08-23",
+    "last_synced": "2026-08-23"
   }
 ]


### PR DESCRIPTION
deja serves a local index of the session transcripts coding agents already write to disk — Claude Code, Codex, Cursor, opencode, Zed and more — so an agent can answer what was done about something before, including work from before deja was installed. BM25 over local files, no LLM and no embeddings, credentials redacted at index time.

Follows `catalog/schema.json`: `tooling` category, stdio install via `deja mcp` (the binary comes from Homebrew, the install script, or `go install`).