### PR TITLE
catalog(mcp): add OrcaReplay to the curated list

### DIFF
--- a/catalog/mcp/curated.json
+++ b/catalog/mcp/curated.json
@@ -783,5 +783,38 @@
     "source": "curated",
     "last_synced": "2026-08-04",
     "added_at": "2026-08-04"
+  },
+  {
+    "id": "orcareplay",
+    "name": "OrcaReplay",
+    "type": "mcp",
+    "description": "Read recorded coding-agent runs: timelines, checkpoints, offline replay and cross-model comparison",
+    "source_url": "https://github.com/Continuum-AI-Corp/OrcaReplay",
+    "stars": 173,
+    "category": "tooling",
+    "tags": [
+      "debugging",
+      "replay",
+      "tracing",
+      "coding-agent",
+      "observability"
+    ],
+    "tech_stack": [
+      "typescript"
+    ],
+    "install": {
+      "method": "mcp_config",
+      "config": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "orcareplay",
+          "mcp"
+        ]
+      }
+    },
+    "source": "curated",
+    "added_at": "2026-09-08",
+    "last_synced": "2026-09-08"
   }
 ]


### PR DESCRIPTION
Adds OrcaReplay to `catalog/mcp/curated.json` — one entry, matching the existing schema.

**Disclosure: I work on it.** Apache-2.0, free, no paid tier, no account.

## Why a PR rather than waiting for the crawler

Your Data Sources table lists [`yzfly/Awesome-MCP-ZH`](https://github.com/yzfly/Awesome-MCP-ZH) as an MCP source, and OrcaReplay **is** already merged into that list. It has not appeared in `catalog/mcp/` yet, so either the pipeline has not re-run since or that source is not the one it picks up. Rather than guess, I have put it in the curated file, which is the manually-maintained half. If the crawler would have got there on its own, close this and I will not resubmit.

## The entry

```json
{
  "id": "orcareplay",
  "name": "OrcaReplay",
  "type": "mcp",
  "description": "Read recorded coding-agent runs: timelines, checkpoints, offline replay and cross-model comparison",
  "source_url": "https://github.com/Continuum-AI-Corp/OrcaReplay",
  "stars": 173,
  "category": "tooling",
  "tags": ["debugging", "replay", "tracing", "coding-agent", "observability"],
  "tech_stack": ["typescript"],
  "install": { "method": "mcp_config", "config": { "command": "npx", "args": ["-y", "orcareplay", "mcp"] } },
  "source": "curated",
  "added_at": "2026-09-08",
  "last_synced": "2026-09-08"
}
```

`stars` is the real current count, 173, not rounded up.

## What the server does

Six read-oriented tools over recorded coding-agent runs — `orca_list_runs`, `orca_show_run`, `orca_checkpoints`, `orca_graph`, `orca_replay`, `orca_compare`. It is the machine-readable half of a record/replay debugger: OrcaReplay captures a run **below** the harness (no SDK, exporter or plugin — it moves a base-URL variable for that process, or terminates TLS for one named host), keeps the verbatim wire bytes, and re-executes the run later with the network off.

Directly relevant to this catalog's subject: adapters exist for Claude Code, Codex CLI, opencode, qwen-code, Cursor, grok-cli, OpenClaw, goose and Hermes, each with a fixture recording the exact environment variables it sets.

## Verify

```bash
npx -y orcareplay mcp        # stdio MCP server, protocol 2025-06-18
```

Published on npm as [`orcareplay`](https://www.npmjs.com/package/orcareplay) (0.2.3, with provenance) and listed in the official MCP Registry as `io.github.Continuum-AI-Corp/orcareplay`.

I have not touched `index.json`, `crawl_state.json` or the generated READMEs — tell me if the curated entry is meant to be reflected there in the same PR and I will regenerate.
